### PR TITLE
Make navigation and menu sticky

### DIFF
--- a/src/scripts/sections/homepage.js
+++ b/src/scripts/sections/homepage.js
@@ -26,12 +26,12 @@ $(document).ready(function() {
   // Main menu toggle
   $('[data-hook=close-main-nav]').click((e) => {
     e.preventDefault();
-    $('body').removeClass('menu-in');
+    $('nav.main-nav').removeClass('menu-in');
   });
 
   $('[data-hook=open-main-nav]').click((e) => {
     e.preventDefault();
-    $('body').addClass('menu-in');
+    $('nav.main-nav').addClass('menu-in');
   });
 
   // Main menu click

--- a/src/styles/modules/globals.scss
+++ b/src/styles/modules/globals.scss
@@ -10,10 +10,6 @@ body {
   font-family: $font-stack-body;
   font-weight: $font-weight-normal;
   font-size: $font-size-base;
-
-  transition: transform 250ms ease-out;
-  transform: translateX(0);
-  will-change: transform;
 }
 
 body.menu-in {

--- a/src/styles/modules/site-header.scss
+++ b/src/styles/modules/site-header.scss
@@ -1,4 +1,16 @@
 /*================ Site Header ================*/
+
+#shopify-section-header {
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: 1001;
+}
+
+#MainContent {
+  margin-top: 54px;
+}
+
 header {
   display: flex;
   flex-direction: row;
@@ -39,16 +51,19 @@ header {
 
 nav.main-nav {
   position: fixed;
-  left: 0;
+  left: -300px;
   top: 0;
   bottom: 0;
   width: 300px;
-  transform: translateX(-100%);
   background: #1a1a1a;
   color: white;
-  z-index: 1000;
-  will-change: transform;
-  transition: transform 250ms ease-out;
+  z-index: 1002;
+  will-change: left;
+  transition: left 250ms ease-out;
+
+  &.menu-in {
+    left: 0;
+  }
 
   .site-nav {
     list-style: none;


### PR DESCRIPTION
Had to make a few changes to the way the navigation was being hidden/shown.
The transform/will-change on the body was breaking the `position: fixed` of
the navbar and menu.

Before, it was using transformX on the content and menu to make them slide left/right.
Now, it simply slides the menu over the content using the `left` property.

Hopefully this doesn't cause any undesired side effects. Tested it locally on desktop
and mobile sized browsers.